### PR TITLE
feat: Adding db_instance_automated_backups_replication

### DIFF
--- a/examples/complete-mssql/README.md
+++ b/examples/complete-mssql/README.md
@@ -33,6 +33,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_db"></a> [db](#module\_db) | ../../ | n/a |
+| <a name="module_db_automated_backups_replication"></a> [db\_automated\_backups\_replication](#module\_db\_automated\_backups\_replication) | ../../modules/db_instance_automated_backups_replication | n/a |
 | <a name="module_db_disabled"></a> [db\_disabled](#module\_db\_disabled) | ../../ | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |

--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -3,8 +3,9 @@ provider "aws" {
 }
 
 locals {
-  name   = "complete-mssql"
-  region = "eu-west-1"
+  name    = "complete-mssql"
+  region  = "eu-west-1"
+  region2 = "eu-central-1"
   tags = {
     Owner       = "user"
     Environment = "dev"
@@ -165,4 +166,22 @@ module "db_disabled" {
   create_db_instance        = false
   create_db_parameter_group = false
   create_db_option_group    = false
+}
+
+################################################################################
+# RDS Automated Backups Replication Module
+################################################################################
+provider "aws" {
+  alias  = "region2"
+  region = local.region2
+}
+
+module "db_automated_backups_replication" {
+  source = "../../modules/db_instance_automated_backups_replication"
+
+  source_db_instance_arn = module.db.db_instance_arn
+
+  providers = {
+    aws = aws.region2
+  }
 }

--- a/examples/complete-oracle/README.md
+++ b/examples/complete-oracle/README.md
@@ -31,6 +31,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_db"></a> [db](#module\_db) | ../../ | n/a |
+| <a name="module_db_automated_backups_replication"></a> [db\_automated\_backups\_replication](#module\_db\_automated\_backups\_replication) | ../../modules/db_instance_automated_backups_replication | n/a |
 | <a name="module_db_disabled"></a> [db\_disabled](#module\_db\_disabled) | ../../ | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |

--- a/examples/complete-oracle/main.tf
+++ b/examples/complete-oracle/main.tf
@@ -3,8 +3,9 @@ provider "aws" {
 }
 
 locals {
-  name   = "complete-oracle"
-  region = "eu-west-1"
+  name    = "complete-oracle"
+  region  = "eu-west-1"
+  region2 = "eu-central-1"
   tags = {
     Owner       = "user"
     Environment = "dev"
@@ -109,4 +110,22 @@ module "db_disabled" {
   create_db_instance        = false
   create_db_parameter_group = false
   create_db_option_group    = false
+}
+
+################################################################################
+# RDS Automated Backups Replication Module
+################################################################################
+provider "aws" {
+  alias  = "region2"
+  region = local.region2
+}
+
+module "db_automated_backups_replication" {
+  source = "../../modules/db_instance_automated_backups_replication"
+
+  source_db_instance_arn = module.db.db_instance_arn
+
+  providers = {
+    aws = aws.region2
+  }
 }

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -31,6 +31,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_db"></a> [db](#module\_db) | ../../ | n/a |
+| <a name="module_db_automated_backups_replication"></a> [db\_automated\_backups\_replication](#module\_db\_automated\_backups\_replication) | ../../modules/db_instance_automated_backups_replication | n/a |
 | <a name="module_db_default"></a> [db\_default](#module\_db\_default) | ../../ | n/a |
 | <a name="module_db_disabled"></a> [db\_disabled](#module\_db\_disabled) | ../../ | n/a |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -3,8 +3,9 @@ provider "aws" {
 }
 
 locals {
-  name   = "complete-postgresql"
-  region = "eu-west-1"
+  name    = "complete-postgresql"
+  region  = "eu-west-1"
+  region2 = "eu-central-1"
   tags = {
     Owner       = "user"
     Environment = "dev"
@@ -163,4 +164,22 @@ module "db_disabled" {
   create_db_instance        = false
   create_db_parameter_group = false
   create_db_option_group    = false
+}
+
+################################################################################
+# RDS Automated Backups Replication Module
+################################################################################
+provider "aws" {
+  alias  = "region2"
+  region = local.region2
+}
+
+module "db_automated_backups_replication" {
+  source = "../../modules/db_instance_automated_backups_replication"
+
+  source_db_instance_arn = module.db.db_instance_arn
+
+  providers = {
+    aws = aws.region2
+  }
 }

--- a/modules/db_instance_automated_backups_replication/main.tf
+++ b/modules/db_instance_automated_backups_replication/main.tf
@@ -1,0 +1,9 @@
+resource "aws_db_instance_automated_backups_replication" "this" {
+  count = var.create ? 1 : 0
+
+  source_db_instance_arn = var.source_db_instance_arn
+  kms_key_id             = var.kms_key_arn
+  pre_signed_url         = var.pre_signed_url
+  retention_period       = var.retention_period
+
+}

--- a/modules/db_instance_automated_backups_replication/outputs.tf
+++ b/modules/db_instance_automated_backups_replication/outputs.tf
@@ -1,0 +1,4 @@
+output "db_instance_automated_backups_replication_id" {
+  description = "The automated backups replication id"
+  value       = try(aws_db_instance_automated_backups_replication.this[0].id, "")
+}

--- a/modules/db_instance_automated_backups_replication/variables.tf
+++ b/modules/db_instance_automated_backups_replication/variables.tf
@@ -1,0 +1,29 @@
+variable "create" {
+  description = "Whether to create this resource or not?"
+  type        = bool
+  default     = true
+}
+
+variable "kms_key_arn" {
+  description = "The KMS encryption key ARN in the destination AWS Region"
+  type        = string
+  default     = null
+}
+
+variable "pre_signed_url" {
+  description = "A URL that contains a Signature Version 4 signed request for the StartDBInstanceAutomatedBackupsReplication action to be called in the AWS Region of the source DB instance"
+  type        = string
+  default     = null
+}
+
+variable "retention_period" {
+  description = "The retention period for the replicated automated backups"
+  type        = number
+  default     = 7
+}
+
+variable "source_db_instance_arn" {
+  description = "The ARN of the source DB instance for the replicated automated backups"
+  type        = string
+  default     = null
+}

--- a/modules/db_instance_automated_backups_replication/versions.tf
+++ b/modules/db_instance_automated_backups_replication/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
+  }
+}


### PR DESCRIPTION
## Description 

To address: https://github.com/terraform-aws-modules/terraform-aws-rds/issues/406

Intent is to open a PR after this is merged back upstream. 

Adding a module for automated backups replication. 

This resource must be created in the destination region. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance_automated_backups_replication

It seems best to not have nested provider modules so in this case a separate module needs to be added as shown in the examples and the additional provider passed to the root module instead. 

Child modules containing their own provider blocks is not recommended: https://www.terraform.io/language/modules/develop/providers

This is available for MSSQL, Oracle, and Postgres databases. 

## Testing

Tested in a dev env on postgres. 
Run terraform init and plans in the examples dir. 

## To Do

This PR is just for these changes. Updates for pre-commit and tool versions separate from this PR. 

