### PR TITLE
fix: Examples Adjustments

### DIFF
--- a/examples/complete-mssql/README.md
+++ b/examples/complete-mssql/README.md
@@ -27,7 +27,6 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
-| <a name="provider_aws.region2"></a> [aws.region2](#provider\_aws.region2) | >= 4.6 |
 
 ## Modules
 
@@ -46,7 +45,6 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_directory_service_directory.demo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory) | resource |
 | [aws_iam_role.rds_ad_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.rds_directory_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_iam_policy_document.rds_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/examples/complete-mssql/README.md
+++ b/examples/complete-mssql/README.md
@@ -27,6 +27,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
+| <a name="provider_aws.region2"></a> [aws.region2](#provider\_aws.region2) | >= 4.6 |
 
 ## Modules
 
@@ -45,6 +46,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_directory_service_directory.demo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory) | resource |
 | [aws_iam_role.rds_ad_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.rds_directory_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_iam_policy_document.rds_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -124,6 +124,7 @@ module "db" {
 
   allocated_storage     = 20
   max_allocated_storage = 100
+  storage_encrypted     = false
 
   username = "complete_mssql"
   port     = 1433
@@ -176,17 +177,10 @@ provider "aws" {
   region = local.region2
 }
 
-resource "aws_kms_key" "default" {
-  description = "Encryption key for cross region automated backups"
-
-  provider = aws.region2
-}
-
 module "db_automated_backups_replication" {
   source = "../../modules/db_instance_automated_backups_replication"
 
   source_db_instance_arn = module.db.db_instance_arn
-  kms_key_arn            = aws_kms_key.default.arn
 
   providers = {
     aws = aws.region2

--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -140,7 +140,7 @@ module "db" {
   enabled_cloudwatch_logs_exports = ["error"]
   create_cloudwatch_log_group     = true
 
-  backup_retention_period = 0
+  backup_retention_period = 1
   skip_final_snapshot     = true
   deletion_protection     = false
 
@@ -176,10 +176,17 @@ provider "aws" {
   region = local.region2
 }
 
+resource "aws_kms_key" "default" {
+  description = "Encryption key for cross region automated backups"
+
+  provider = aws.region2
+}
+
 module "db_automated_backups_replication" {
   source = "../../modules/db_instance_automated_backups_replication"
 
   source_db_instance_arn = module.db.db_instance_arn
+  kms_key_arn            = aws_kms_key.default.arn
 
   providers = {
     aws = aws.region2

--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -124,7 +124,9 @@ module "db" {
 
   allocated_storage     = 20
   max_allocated_storage = 100
-  storage_encrypted     = false
+
+  # Encryption at rest is not available for DB instances running SQL Server Express Edition
+  storage_encrypted = false
 
   username = "complete_mssql"
   port     = 1433

--- a/examples/complete-oracle/README.md
+++ b/examples/complete-oracle/README.md
@@ -24,7 +24,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.region2"></a> [aws.region2](#provider\_aws.region2) | >= 4.6 |
 
 ## Modules
 
@@ -38,7 +40,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 
 ## Inputs
 

--- a/examples/complete-oracle/main.tf
+++ b/examples/complete-oracle/main.tf
@@ -88,7 +88,7 @@ module "db" {
   enabled_cloudwatch_logs_exports = ["alert", "audit"]
   create_cloudwatch_log_group     = true
 
-  backup_retention_period = 0
+  backup_retention_period = 1
   skip_final_snapshot     = true
   deletion_protection     = false
 
@@ -120,10 +120,17 @@ provider "aws" {
   region = local.region2
 }
 
+resource "aws_kms_key" "default" {
+  description = "Encryption key for cross region automated backups"
+
+  provider = aws.region2
+}
+
 module "db_automated_backups_replication" {
   source = "../../modules/db_instance_automated_backups_replication"
 
   source_db_instance_arn = module.db.db_instance_arn
+  kms_key_arn            = aws_kms_key.default.arn
 
   providers = {
     aws = aws.region2

--- a/examples/complete-oracle/main.tf
+++ b/examples/complete-oracle/main.tf
@@ -66,8 +66,8 @@ module "db" {
 
   engine               = "oracle-ee"
   engine_version       = "19.0.0.0.ru-2021-10.rur-2021-10.r1"
-  family               = "oracle-ee-19.0" # DB parameter group
-  major_engine_version = "19.0"           # DB option group
+  family               = "oracle-ee-19" # DB parameter group
+  major_engine_version = "19"           # DB option group
   instance_class       = "db.t3.large"
   license_model        = "bring-your-own-license"
 
@@ -75,7 +75,8 @@ module "db" {
   max_allocated_storage = 100
 
   # Make sure that database name is capitalized, otherwise RDS will try to recreate RDS instance every time
-  db_name  = "COMPLETEORACLE"
+  # Oracle database name cannot be longer than 8 characters
+  db_name  = "ORACLE"
   username = "complete_oracle"
   port     = 1521
 

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -24,7 +24,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.region2"></a> [aws.region2](#provider\_aws.region2) | >= 4.6 |
 
 ## Modules
 
@@ -39,7 +41,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 
 ## Inputs
 

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -91,7 +91,7 @@ module "db" {
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   create_cloudwatch_log_group     = true
 
-  backup_retention_period = 0
+  backup_retention_period = 1
   skip_final_snapshot     = true
   deletion_protection     = false
 
@@ -174,10 +174,17 @@ provider "aws" {
   region = local.region2
 }
 
+resource "aws_kms_key" "default" {
+  description = "Encryption key for cross region automated backups"
+
+  provider = aws.region2
+}
+
 module "db_automated_backups_replication" {
   source = "../../modules/db_instance_automated_backups_replication"
 
   source_db_instance_arn = module.db.db_instance_arn
+  kms_key_arn            = aws_kms_key.default.arn
 
   providers = {
     aws = aws.region2


### PR DESCRIPTION
## Description 

Backup retention needs to be set in order for cross region automated backups to be applied. 

Also since primary DB storage that is created in the example is encrypted by default, we must supply a KMS key to use for cross region snapshot encryption as well. 

Added some fixes to be able to run the applies for the examples. 
- mssql: encryption at rest is not available for sql server ex https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html
- oracle: `db_name` must be no ore than 8 chars https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
- oracle: adjust parameter and option group family and major engine version
![Screen Shot 2022-06-28 at 3 01 44 PM](https://user-images.githubusercontent.com/69476188/176262794-efd9b7f3-b561-46eb-8aef-487ca0600d4e.png)

## Tests

Ran full applies in a sandbox account in each of the example directories applicable:

- [x] complete-mssql
- [x] complete-oracle
- [x] complete-postgres

Note: Cross region automated backups feature is not available on mysql so that is why it is not added to that directory. 

As part of changes for: https://github.com/terraform-aws-modules/terraform-aws-rds/issues/406

There is an open PR upstream to fix other example issues. 