### PR TITLE
fix: Update examples with terraform-aws-kms module

### DIFF
--- a/examples/complete-oracle/README.md
+++ b/examples/complete-oracle/README.md
@@ -26,7 +26,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region2"></a> [aws.region2](#provider\_aws.region2) | >= 4.6 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
 
 ## Modules
 
@@ -35,6 +35,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_db"></a> [db](#module\_db) | ../../ | n/a |
 | <a name="module_db_automated_backups_replication"></a> [db\_automated\_backups\_replication](#module\_db\_automated\_backups\_replication) | ../../modules/db_instance_automated_backups_replication | n/a |
 | <a name="module_db_disabled"></a> [db\_disabled](#module\_db\_disabled) | ../../ | n/a |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 1.0 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
@@ -42,7 +43,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/examples/complete-oracle/main.tf
+++ b/examples/complete-oracle/main.tf
@@ -125,8 +125,9 @@ provider "aws" {
 }
 
 module "kms" {
-  source  = "terraform-aws-modules/kms/aws"
-  version = "~> 1.0"
+  source      = "terraform-aws-modules/kms/aws"
+  version     = "~> 1.0"
+  description = "KMS key for cross region automated backups replication"
 
   # Aliases
   aliases                 = [local.name]

--- a/examples/complete-oracle/main.tf
+++ b/examples/complete-oracle/main.tf
@@ -2,10 +2,13 @@ provider "aws" {
   region = local.region
 }
 
+data "aws_caller_identity" "current" {}
+
 locals {
-  name    = "complete-oracle"
-  region  = "eu-west-1"
-  region2 = "eu-central-1"
+  name             = "complete-oracle"
+  region           = "eu-west-1"
+  region2          = "eu-central-1"
+  current_identity = data.aws_caller_identity.current.arn
   tags = {
     Owner       = "user"
     Environment = "dev"
@@ -121,17 +124,28 @@ provider "aws" {
   region = local.region2
 }
 
-resource "aws_kms_key" "default" {
-  description = "Encryption key for cross region automated backups"
+module "kms" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 1.0"
 
-  provider = aws.region2
+  # Aliases
+  aliases                 = [local.name]
+  aliases_use_name_prefix = true
+
+  key_owners = [local.current_identity]
+
+  tags = local.tags
+
+  providers = {
+    aws = aws.region2
+  }
 }
 
 module "db_automated_backups_replication" {
   source = "../../modules/db_instance_automated_backups_replication"
 
   source_db_instance_arn = module.db.db_instance_arn
-  kms_key_arn            = aws_kms_key.default.arn
+  kms_key_arn            = module.kms.key_arn
 
   providers = {
     aws = aws.region2

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -26,7 +26,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.region2"></a> [aws.region2](#provider\_aws.region2) | >= 4.6 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
 
 ## Modules
 
@@ -36,6 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_db_automated_backups_replication"></a> [db\_automated\_backups\_replication](#module\_db\_automated\_backups\_replication) | ../../modules/db_instance_automated_backups_replication | n/a |
 | <a name="module_db_default"></a> [db\_default](#module\_db\_default) | ../../ | n/a |
 | <a name="module_db_disabled"></a> [db\_disabled](#module\_db\_disabled) | ../../ | n/a |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 1.0 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
@@ -43,7 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -179,8 +179,9 @@ provider "aws" {
 }
 
 module "kms" {
-  source  = "terraform-aws-modules/kms/aws"
-  version = "~> 1.0"
+  source      = "terraform-aws-modules/kms/aws"
+  version     = "~> 1.0"
+  description = "KMS key for cross region automated backups replication"
 
   # Aliases
   aliases                 = [local.name]

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -2,10 +2,13 @@ provider "aws" {
   region = local.region
 }
 
+data "aws_caller_identity" "current" {}
+
 locals {
-  name    = "complete-postgresql"
-  region  = "eu-west-1"
-  region2 = "eu-central-1"
+  name             = "complete-postgresql"
+  region           = "eu-west-1"
+  region2          = "eu-central-1"
+  current_identity = data.aws_caller_identity.current.arn
   tags = {
     Owner       = "user"
     Environment = "dev"
@@ -175,17 +178,28 @@ provider "aws" {
   region = local.region2
 }
 
-resource "aws_kms_key" "default" {
-  description = "Encryption key for cross region automated backups"
+module "kms" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 1.0"
 
-  provider = aws.region2
+  # Aliases
+  aliases                 = [local.name]
+  aliases_use_name_prefix = true
+
+  key_owners = [local.current_identity]
+
+  tags = local.tags
+
+  providers = {
+    aws = aws.region2
+  }
 }
 
 module "db_automated_backups_replication" {
   source = "../../modules/db_instance_automated_backups_replication"
 
   source_db_instance_arn = module.db.db_instance_arn
-  kms_key_arn            = aws_kms_key.default.arn
+  kms_key_arn            = module.kms.key_arn
 
   providers = {
     aws = aws.region2


### PR DESCRIPTION
## Description 

Updating examples to make use of `terraform-aws-kms` module in place of aws_kms_key resources. 

Ran both `examples/complete-postgres` and `examples/complete-oracle` applies in a sandbox account with no issues and desired results. 